### PR TITLE
DOPS-18593 Bump runtime from node20 to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,14 +17,14 @@ jobs:
       new_sha: ${{ steps.commit-dist.outputs.new_sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main'}}
     steps:
       - name: Checkout updated main with dist/
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ outputs:
     description: 'URL of the uploaded package'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary of changes
https://orchard.atlassian.net/browse/DOPS-18593

`arbor-education/private-packagist-upload-artifact` declares `using: 'node20'` in `action.yml`. GitHub is removing Node.js 20 from runners on **September 16, 2026** (soft default: June 16, 2026), after which the action will fail in any workflow that uses it.

This PR changes the runtime declaration to `node24` and bumps the CI and release workflows to node24 as well. No application code or dist changes are included - the existing `dist/index.js` is plain bundled JavaScript fully compatible with Node.js 24 (`engines.node: >=18` was already declared in `package.json`). The `tag-release.yml` workflow will rebuild `dist/` with node24 automatically on merge.

Files changed:
- `action.yml` - `using: 'node20'` → `using: 'node24'`
- `.github/workflows/ci.yml` - `checkout@v4` → v6, `setup-node@v4` → v6, `node-version: '20'` → `'24'`
- `.github/workflows/tag-release.yml` - same bumps (ensures dist is rebuilt with node24 on release)

### Areas to focus on
- `action.yml` - the one-line runtime change.
- `tag-release.yml` - now rebuilds and publishes dist using node24, which is the correct runtime.

### Notes for code owners
Merging will auto-trigger `tag-release.yml` which rebuilds `dist/` with node24, creates a new patch tag (e.g. `v1.0.1`), and updates the `v1` floating tag. Consumers pinned to `@v1` will automatically get the node24 version. `arbor-fe-library` is the known consumer.

### Breaking changes
None. All inputs, outputs, and behaviour are identical.

---

## Test evidence

CI passes on the PR branch - 29/29 tests pass: https://github.com/arbor-education/private-packagist-upload-artifact/actions/runs/27548176776 ✅

```
Test Suites: 2 passed, 2 total
Tests:       29 passed, 29 total
```