### PR TITLE
DOPS-18593 Bump version to 2.0.0 for node24 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-packagist-upload-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-packagist-upload-action",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-packagist-upload-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "GitHub Action to upload artifacts to Private Packagist",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary of changes
https://orchard.atlassian.net/browse/DOPS-18593

Bumps `package.json` version from `1.0.0` to `2.0.0` so the `tag-release.yml` workflow creates a `v2.0.0` release on merge.

The previous PR (#4) changed the action runtime to node24 but the `tag-release.yml` failed because `v1.0.0` already existed - it tried to push a version bump commit back to main which branch protection blocked. With version set to `2.0.0`, the workflow finds `v2.0.0` doesn't exist, skips the increment block entirely, and creates the tag and release cleanly.

### Breaking changes
None - callers using `@v1` will need to update to `@v2` to get the node24 runtime.